### PR TITLE
Use shortGuid for Posts

### DIFF
--- a/Ikv.ScreenshotWarehouse.Api/Ikv.ScreenshotWarehouse.Api.csproj
+++ b/Ikv.ScreenshotWarehouse.Api/Ikv.ScreenshotWarehouse.Api.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="CloudinaryDotNet" Version="1.17.0" />
+        <PackageReference Include="CSharpVitamins.ShortGuid" Version="2.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.13" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.10">

--- a/Ikv.ScreenshotWarehouse.Api/Persistence/Entities/Post.cs
+++ b/Ikv.ScreenshotWarehouse.Api/Persistence/Entities/Post.cs
@@ -12,6 +12,7 @@ namespace Ikv.ScreenshotWarehouse.Api.Persistence.Entities
         public string FileURL { get; set; }
         public DateTime ScreenshotDate { get; set; }
         public string GameMap { get; set; }
+        public bool IsValidated { get; set; }
         public User User { get; set; }
         public long UserId { get; set; }
     }

--- a/Ikv.ScreenshotWarehouse.Api/Services/PostService.cs
+++ b/Ikv.ScreenshotWarehouse.Api/Services/PostService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using CSharpVitamins;
 using Ikv.ScreenshotWarehouse.Api.Helpers;
 using Ikv.ScreenshotWarehouse.Api.Persistence.Entities;
 using Ikv.ScreenshotWarehouse.Api.Repositories;
@@ -30,12 +31,13 @@ namespace Ikv.ScreenshotWarehouse.Api.Services
                 Category = model.Category,
                 Title = model.Title,
                 GameMap = model.GameMap,
-                UserId = userId
+                UserId = userId,
+                CreatedAt = DateTime.Now,
+                UpdatedAt = DateTime.Now,
             };
-            post.CreatedAt = DateTime.Now;
-            post.UpdatedAt = DateTime.Now;
-            post.Id = DateTime.Now.ToString(); //TODO use short uuid
-            post.FileURL = "NOT IMPLEMENTED YET";
+            post.Id = ShortGuid.NewGuid();
+            var url = await _cloudinaryHelper.UploadBase64Image(model.FileBase64, userId.ToString());
+            post.FileURL = url;
             return await _postRepository.SavePost(post);
         }
     }

--- a/Ikv.ScreenshotWarehouse.Api/Startup.cs
+++ b/Ikv.ScreenshotWarehouse.Api/Startup.cs
@@ -33,8 +33,7 @@ namespace Ikv.ScreenshotWarehouse.Api
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRouting(opt => opt.LowercaseUrls = true);
-            services.AddControllers().AddJsonOptions(options =>
-                options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.Preserve);
+            services.AddControllers();
             
             services.AddDbContext<IkvContext>(options => options.UseNpgsql(DbConnString));
 

--- a/Ikv.ScreenshotWarehouse.Api/V1/Controllers/PostController.cs
+++ b/Ikv.ScreenshotWarehouse.Api/V1/Controllers/PostController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Ikv.ScreenshotWarehouse.Api.Services;
 using Ikv.ScreenshotWarehouse.Api.V1.Models.RequestModels;
+using Ikv.ScreenshotWarehouse.Api.V1.Models.ResponseModels;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Ikv.ScreenshotWarehouse.Api.V1.Controllers
@@ -16,12 +17,13 @@ namespace Ikv.ScreenshotWarehouse.Api.V1.Controllers
         {
             _postService = postService;
         }
-        
+
         [HttpGet("{postId}")]
         public async Task<IActionResult> GetPostById([FromRoute] string postId)
         {
             var post = await _postService.GetPostById(postId);
-            return Ok(post);
+            var postResponseModel = new PostResponseModel(post);
+            return Ok(postResponseModel);
         }
 
         [HttpPost]
@@ -29,8 +31,9 @@ namespace Ikv.ScreenshotWarehouse.Api.V1.Controllers
         {
             var userId = HttpContext.User.Claims.FirstOrDefault(x => x.Type == "id")?.Value;
 
-            var post= await _postService.SaveScreenshot(model, userId == null ? 1 : long.Parse(userId));
-            return Ok(post);
+            var post = await _postService.SaveScreenshot(model, userId == null ? 1 : long.Parse(userId));
+            var postResponseModel = new PostResponseModel(post);
+            return Ok(postResponseModel);
         }
     }
 }

--- a/Ikv.ScreenshotWarehouse.Api/V1/Models/ResponseModels/PostResponseModel.cs
+++ b/Ikv.ScreenshotWarehouse.Api/V1/Models/ResponseModels/PostResponseModel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Ikv.ScreenshotWarehouse.Api.Persistence.Entities;
+
+namespace Ikv.ScreenshotWarehouse.Api.V1.Models.ResponseModels
+{
+    public class PostResponseModel
+    {
+        public string Id { get; set; }
+        public string Username { get; set; }
+        public long UserId { get; set; }
+        public string Category { get; set; }
+        public string Title { get; set; }
+        public string FileUrl { get; set; }
+        public DateTime ScreenshotDate { get; set; }
+        public string GameMap { get; set; }
+        public bool IsValidated { get; set; }
+
+        public PostResponseModel(Post post)
+        {
+            Id = post.Id;
+            Username = post.User.Username;
+            UserId = post.UserId;
+            Category = post.Category;
+            Title = post.Title;
+            FileUrl = post.FileURL;
+            ScreenshotDate = post.ScreenshotDate;
+            GameMap = post.GameMap;
+            IsValidated = post.IsValidated;
+        }
+    }
+}


### PR DESCRIPTION
Posts needs to have a string id. Used ShortGuid for posts.
IsValidated added to post model.
Post model response model added.
Json serialize circular dependency prevented with post response model.
Deleted  "options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.Preserve" we don't need it anymore